### PR TITLE
tfconfig: Test for handling of a block with its brace on the next line

### DIFF
--- a/tfconfig/test-fixtures/invalid-braces/invalid-braces.out.json
+++ b/tfconfig/test-fixtures/invalid-braces/invalid-braces.out.json
@@ -1,0 +1,18 @@
+{
+    "path": "test-fixtures/invalid-braces",
+    "variables": {
+        "foo": {
+            "name": "foo",
+            "default": "123",
+            "pos": {
+                "filename": "test-fixtures/invalid-braces/invalid-braces.tf",
+                "line": 5
+            }
+        }
+    },
+    "outputs": {},
+    "required_providers": {},
+    "managed_resources": {},
+    "data_resources": {},
+    "module_calls": {}
+}

--- a/tfconfig/test-fixtures/invalid-braces/invalid-braces.tf
+++ b/tfconfig/test-fixtures/invalid-braces/invalid-braces.tf
@@ -1,0 +1,8 @@
+# The opening brace is required to be on the same line as the block header
+# under HCL 2, and so this should produce an error, causing us to use HCL 1's
+# parser instead.
+
+variable foo
+{
+  default = "123"
+}


### PR DESCRIPTION
This new test is covering a syntax error case that we were previously not handling gracefully. The change is actually in the HCL2 repository, to make this return a non-nil empty body in the case of a syntax error, but since this codebase is _relying_ on that we'll test it up here too, to reduce the risk of this inadvertently regressing in future.

A convention in HCL2 is that functions which return diagnostics should return a "best effort" valid-but-possibly-incomplete object when returning errors, since this then allows some careful analysis of the partial object to generate a more complete set of errors. We don't return nil bodies in any other case, so it's best here to return an empty one to meet the "valid-but-incomplete" requirement.
