### PR TITLE
Add CODEOWNERS specifying ownership by the terraform-core team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# This codebase is primarily maintained by the Terraform Core team.
+* @hashicorp/terraform-core


### PR DESCRIPTION
Since this is a bit of an ancillary codebase, we'll include this here
mostly as documentation for humans at HashiCorp, but it will also serve
to help assign approvers automatically in pull requests.