### PR TITLE
tfconfig/load_hcl: merge overridden module blocks nicely

### DIFF
--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -284,6 +284,12 @@ func loadModule(dir string) (*Module, Diagnostics) {
 					Pos:  sourcePosHCL(block.DefRange),
 				}
 
+				// check if this is overriding an existing module
+				var origSource string
+				if origMod, exists := mod.ModuleCalls[name]; exists {
+					origSource = origMod.Source
+				}
+
 				mod.ModuleCalls[name] = mc
 
 				if attr, defined := content.Attributes["source"]; defined {
@@ -291,6 +297,10 @@ func loadModule(dir string) (*Module, Diagnostics) {
 					valDiags := gohcl.DecodeExpression(attr.Expr, nil, &source)
 					diags = append(diags, valDiags...)
 					mc.Source = source
+				}
+
+				if mc.Source == "" {
+					mc.Source = origSource
 				}
 
 				if attr, defined := content.Attributes["version"]; defined {

--- a/tfconfig/load_legacy.go
+++ b/tfconfig/load_legacy.go
@@ -237,8 +237,11 @@ func loadModuleLegacyHCL(dir string) (*Module, Diagnostics) {
 					Version: block.Version,
 					Pos:     sourcePosLegacyHCL(item.Pos(), filename),
 				}
-				if _, exists := mod.ModuleCalls[name]; exists {
-					return nil, diagnosticsErrorf("duplicate module block for %q", name)
+				// it's possible this module call is from an override file
+				if origMod, exists := mod.ModuleCalls[name]; exists {
+					if mc.Source == "" {
+						mc.Source = origMod.Source
+					}
 				}
 				mod.ModuleCalls[name] = mc
 			}

--- a/tfconfig/test-fixtures/overrides/overrides_override.tf
+++ b/tfconfig/test-fixtures/overrides/overrides_override.tf
@@ -12,7 +12,6 @@ output "A" {
 }
 
 module "foo" {
-  source  = "foo/bar/baz"
   version = "1.0.2_override"
 
   unused = 2


### PR DESCRIPTION
If a module is overridden and the override does not include "source", use the originally-defined module source.

See also https://github.com/hashicorp/terraform/issues/20550