### PR TITLE
Add cli flag for accepting custom rendering template

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultTemplate(t *testing.T) {
+	module, _ := tfconfig.LoadModule("test-fixtures")
+	buf := new(bytes.Buffer)
+	err := showModuleMarkdown(module, defaultMarkdownTemplate, buf)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+
+	expected, err := ioutil.ReadFile(filepath.Join("test-fixtures", "default.md"))
+	actual := buf.String()
+	if actual != string(expected) {
+		t.Errorf("default template produced unexpected output:\n%s", actual)
+	}
+}
+
+func TestValidCustomTemplate(t *testing.T) {
+	module, _ := tfconfig.LoadModule("test-fixtures")
+	buf := new(bytes.Buffer)
+	customTemplate, err := ioutil.ReadFile(filepath.Join("test-fixtures", "valid-custom.tmpl"))
+	if err != nil {
+		t.Fatalf("failed to read template file: %s", err)
+	}
+
+	err = showModuleMarkdown(module, string(customTemplate), buf)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+
+	expected, err := ioutil.ReadFile(filepath.Join("test-fixtures", "valid-custom.md"))
+	actual := buf.String()
+	if actual != string(expected) {
+		t.Errorf("custom template produced unexpected output:\n%s", actual)
+	}
+}
+
+func TestInvalidTemplate(t *testing.T) {
+	module, _ := tfconfig.LoadModule("test-fixtures")
+	buf := new(bytes.Buffer)
+	customTemplate, err := ioutil.ReadFile(filepath.Join("test-fixtures", "invalid-custom.tmpl"))
+	if err != nil {
+		t.Fatalf("failed to read template file: %s", err)
+	}
+
+	err = showModuleMarkdown(module, string(customTemplate), buf)
+	if err == nil {
+		t.Fatalf("err was nil; expected an error for an invalid template")
+	}
+	if err.Error() != "template: md:9: unexpected EOF" {
+		t.Errorf("invalid template produced an unexpected error: %s", err)
+	}
+}

--- a/test-fixtures/default.md
+++ b/test-fixtures/default.md
@@ -1,0 +1,18 @@
+
+# Module `test-fixtures`
+
+Provider Requirements:
+* **null:** (any version)
+
+## Input Variables
+* `A` (default `"A default"`)
+* `B` (required): The B variable
+
+## Output Values
+* `A`
+* `B`: I am B
+
+## Managed Resources
+* `null_resource.A` from `null`
+* `null_resource.B` from `null`
+

--- a/test-fixtures/invalid-custom.tmpl
+++ b/test-fixtures/invalid-custom.tmpl
@@ -1,0 +1,8 @@
+Module {{ tt .Path }}
+=====================
+
+{{- if .RequiredCore}}
+
+Core Version Constraints:
+{{- range .RequiredCore }}
+* {{ tt . }}

--- a/test-fixtures/main.tf
+++ b/test-fixtures/main.tf
@@ -1,0 +1,19 @@
+variable "A" {
+    default = "A default"
+}
+
+variable "B" {
+    description = "The B variable"
+}
+
+output "A" {
+    value = var.A
+}
+
+output "B" {
+    description = "I am B"
+    value = var.A
+}
+
+resource "null_resource" "A" {}
+resource "null_resource" "B" {}

--- a/test-fixtures/valid-custom.md
+++ b/test-fixtures/valid-custom.md
@@ -1,0 +1,20 @@
+Module `test-fixtures`
+=====================
+
+Provider Requirements:
+* **null:** (any version)
+
+Input Variables
+---------------
+* `A` (default `"A default"`)
+* `B` (required): The B variable
+
+Output Values
+-------------
+* `A`
+* `B`: I am B
+
+Managed Resources
+-----------------
+* `null_resource.A` from `null`
+* `null_resource.B` from `null`

--- a/test-fixtures/valid-custom.tmpl
+++ b/test-fixtures/valid-custom.tmpl
@@ -1,0 +1,73 @@
+Module {{ tt .Path }}
+=====================
+
+{{- if .RequiredCore}}
+
+Core Version Constraints:
+{{- range .RequiredCore }}
+* {{ tt . }}
+{{- end}}{{end}}
+
+{{- if .RequiredProviders}}
+
+Provider Requirements:
+{{- range $name, $versions := .RequiredProviders }}
+* **{{ $name }}:** {{ if $versions }}{{ commas $versions | tt }}{{ else }}(any version){{ end }}
+{{- end}}{{end}}
+
+{{- if .Variables}}
+
+Input Variables
+---------------
+{{- range .Variables }}
+* {{ tt .Name }}{{ if .Default }} (default {{ json .Default | tt }}){{else}} (required){{end}}
+{{- if .Description}}: {{ .Description }}{{ end }}
+{{- end}}{{end}}
+
+{{- if .Outputs}}
+
+Output Values
+-------------
+{{- range .Outputs }}
+* {{ tt .Name }}{{ if .Description}}: {{ .Description }}{{ end }}
+{{- end}}{{end}}
+
+{{- if .ManagedResources}}
+
+Managed Resources
+-----------------
+{{- range .ManagedResources }}
+* {{ printf "%s.%s" .Type .Name | tt }} from {{ tt .Provider.Name }}
+{{- end}}{{end}}
+
+{{- if .DataResources}}
+
+Data Resources
+--------------
+{{- range .DataResources }}
+* {{ printf "data.%s.%s" .Type .Name | tt }} from {{ tt .Provider.Name }}
+{{- end}}{{end}}
+
+{{- if .ModuleCalls}}
+
+Child Modules
+-------------
+{{- range .ModuleCalls }}
+* {{ tt .Name }} from {{ tt .Source }}{{ if .Version }} ({{ tt .Version }}){{ end }}
+{{- end}}{{end}}
+
+{{- if .Diagnostics}}
+
+Problems
+-------------
+{{- range .Diagnostics }}
+
+{{ severity .Severity }}{{ .Summary }}{{ if .Pos }}
+-------------
+
+(at {{ tt .Pos.Filename }} line {{ .Pos.Line }}{{ end }})
+{{ if .Detail }}
+{{ .Detail }}
+{{- end }}
+
+{{- end}}{{end}}


### PR DESCRIPTION
The markdown output is convenient but opinionated.  It would be nice to take a custom template to control the final output.

This PR adds the `template` cli flag to use a custom render template to control the output.