### PR TITLE
Add defined providers to module inspection

### DIFF
--- a/tfconfig/load.go
+++ b/tfconfig/load.go
@@ -45,15 +45,6 @@ func IsModuleDir(dir string) bool {
 	return true
 }
 
-func contains(providers []*ProviderRef, provider ProviderRef) bool {
-	for _, existing := range providers {
-		if *existing == provider {
-			return true
-		}
-	}
-	return false
-}
-
 func (m *Module) init(diags Diagnostics) {
 	// Fill in any additional provider requirements that are implied by
 	// resource configurations, to avoid the caller from needing to apply
@@ -64,7 +55,7 @@ func (m *Module) init(diags Diagnostics) {
 		if _, exists := m.RequiredProviders[r.Provider.Name]; !exists {
 			m.RequiredProviders[r.Provider.Name] = []string{}
 		}
-		if !contains(m.DefinedProviders, r.Provider) && !contains(m.ImplicitProviders, r.Provider) {
+		if !m.DefinedProviders.contains(r.Provider) && !m.ImplicitProviders.contains(r.Provider) {
 			m.ImplicitProviders = append(m.ImplicitProviders, &r.Provider)
 		}
 	}
@@ -72,13 +63,13 @@ func (m *Module) init(diags Diagnostics) {
 		if _, exists := m.RequiredProviders[r.Provider.Name]; !exists {
 			m.RequiredProviders[r.Provider.Name] = []string{}
 		}
-		if !contains(m.DefinedProviders, r.Provider) && !contains(m.ImplicitProviders, r.Provider) {
+		if !m.DefinedProviders.contains(r.Provider) && !m.ImplicitProviders.contains(r.Provider) {
 			m.ImplicitProviders = append(m.ImplicitProviders, &r.Provider)
 		}
 	}
 
-	sort.Sort(providersSortedByName(m.DefinedProviders))
-	sort.Sort(providersSortedByName(m.ImplicitProviders))
+	sort.Sort(m.DefinedProviders)
+	sort.Sort(m.ImplicitProviders)
 
 	// We redundantly also reference the diagnostics from inside the module
 	// object, primarily so that we can easily included in JSON-serialized

--- a/tfconfig/load.go
+++ b/tfconfig/load.go
@@ -47,7 +47,7 @@ func IsModuleDir(dir string) bool {
 
 func contains(providers []*ProviderRef, provider ProviderRef) bool {
 	for _, existing := range providers {
-		if provider == *existing {
+		if *existing == provider {
 			return true
 		}
 	}
@@ -64,20 +64,21 @@ func (m *Module) init(diags Diagnostics) {
 		if _, exists := m.RequiredProviders[r.Provider.Name]; !exists {
 			m.RequiredProviders[r.Provider.Name] = []string{}
 		}
-		if !contains(m.DefinedProviders, r.Provider) {
-			m.DefinedProviders = append(m.DefinedProviders, &r.Provider)
+		if !contains(m.DefinedProviders, r.Provider) && !contains(m.ImplicitProviders, r.Provider) {
+			m.ImplicitProviders = append(m.ImplicitProviders, &r.Provider)
 		}
 	}
 	for _, r := range m.DataResources {
 		if _, exists := m.RequiredProviders[r.Provider.Name]; !exists {
 			m.RequiredProviders[r.Provider.Name] = []string{}
 		}
-		if !contains(m.DefinedProviders, r.Provider) {
-			m.DefinedProviders = append(m.DefinedProviders, &r.Provider)
+		if !contains(m.DefinedProviders, r.Provider) && !contains(m.ImplicitProviders, r.Provider) {
+			m.ImplicitProviders = append(m.ImplicitProviders, &r.Provider)
 		}
 	}
 
 	sort.Sort(providersSortedByName(m.DefinedProviders))
+	sort.Sort(providersSortedByName(m.ImplicitProviders))
 
 	// We redundantly also reference the diagnostics from inside the module
 	// object, primarily so that we can easily included in JSON-serialized

--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -194,6 +194,23 @@ func loadModule(dir string) (*Module, Diagnostics) {
 					mod.RequiredProviders[name] = []string{}
 				}
 
+				if attr, defined := content.Attributes["alias"]; defined {
+					var alias string
+					valDiags := gohcl.DecodeExpression(attr.Expr, nil, &alias)
+					diags = append(diags, valDiags...)
+					if !valDiags.HasErrors() {
+						mod.DefinedProviders = append(mod.DefinedProviders, &ProviderRef{
+							Name:  name,
+							Alias: alias,
+						})
+					}
+				} else {
+					mod.DefinedProviders = append(mod.DefinedProviders, &ProviderRef{
+						Name:  name,
+						Alias: "",
+					})
+				}
+
 			case "resource", "data":
 
 				content, _, contentDiags := block.Body.PartialContent(resourceSchema)

--- a/tfconfig/load_legacy.go
+++ b/tfconfig/load_legacy.go
@@ -251,6 +251,7 @@ func loadModuleLegacyHCL(dir string) (*Module, Diagnostics) {
 			providerConfigs = providerConfigs.Children()
 			type ProviderBlock struct {
 				Version string
+				Alias   string
 			}
 
 			for _, item := range providerConfigs.Items {
@@ -271,6 +272,11 @@ func loadModuleLegacyHCL(dir string) (*Module, Diagnostics) {
 				if block.Version != "" {
 					mod.RequiredProviders[name] = append(mod.RequiredProviders[name], block.Version)
 				}
+
+				mod.DefinedProviders = append(mod.DefinedProviders, &ProviderRef{
+					Name:  name,
+					Alias: block.Alias,
+				})
 
 				// Even if there wasn't an explicit version required, we still
 				// need an entry in our map to signal the unversioned dependency.

--- a/tfconfig/module.go
+++ b/tfconfig/module.go
@@ -12,6 +12,7 @@ type Module struct {
 	RequiredCore      []string            `json:"required_core,omitempty"`
 	RequiredProviders map[string][]string `json:"required_providers"`
 	DefinedProviders  []*ProviderRef      `json:"defined_providers,omitempty"`
+	ImplicitProviders []*ProviderRef      `json:"implicit_providers,omitempty"`
 
 	ManagedResources map[string]*Resource   `json:"managed_resources"`
 	DataResources    map[string]*Resource   `json:"data_resources"`

--- a/tfconfig/module.go
+++ b/tfconfig/module.go
@@ -11,8 +11,8 @@ type Module struct {
 
 	RequiredCore      []string            `json:"required_core,omitempty"`
 	RequiredProviders map[string][]string `json:"required_providers"`
-	DefinedProviders  []*ProviderRef      `json:"defined_providers,omitempty"`
-	ImplicitProviders []*ProviderRef      `json:"implicit_providers,omitempty"`
+	DefinedProviders  providerRefs        `json:"defined_providers,omitempty"`
+	ImplicitProviders providerRefs        `json:"implicit_providers,omitempty"`
 
 	ManagedResources map[string]*Resource   `json:"managed_resources"`
 	DataResources    map[string]*Resource   `json:"data_resources"`

--- a/tfconfig/module.go
+++ b/tfconfig/module.go
@@ -11,6 +11,7 @@ type Module struct {
 
 	RequiredCore      []string            `json:"required_core,omitempty"`
 	RequiredProviders map[string][]string `json:"required_providers"`
+	DefinedProviders  []*ProviderRef      `json:"defined_providers,omitempty"`
 
 	ManagedResources map[string]*Resource   `json:"managed_resources"`
 	DataResources    map[string]*Resource   `json:"data_resources"`

--- a/tfconfig/provider_ref.go
+++ b/tfconfig/provider_ref.go
@@ -8,16 +8,25 @@ type ProviderRef struct {
 	Alias string `json:"alias,omitempty"` // Empty if the default provider configuration is referenced
 }
 
-type providersSortedByName []*ProviderRef
+type providerRefs []*ProviderRef
 
-func (a providersSortedByName) Len() int {
+func (a providerRefs) Len() int {
 	return len(a)
 }
 
-func (a providersSortedByName) Swap(i, j int) {
+func (a providerRefs) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 
-func (a providersSortedByName) Less(i, j int) bool {
+func (a providerRefs) Less(i, j int) bool {
 	return a[i].Name < a[j].Name || (a[i].Name == a[j].Name && a[i].Alias < a[j].Alias)
+}
+
+func (a providerRefs) contains(provider ProviderRef) bool {
+	for _, existing := range a {
+		if *existing == provider {
+			return true
+		}
+	}
+	return false
 }

--- a/tfconfig/provider_ref.go
+++ b/tfconfig/provider_ref.go
@@ -7,3 +7,17 @@ type ProviderRef struct {
 	Name  string `json:"name"`
 	Alias string `json:"alias,omitempty"` // Empty if the default provider configuration is referenced
 }
+
+type providersSortedByName []*ProviderRef
+
+func (a providersSortedByName) Len() int {
+	return len(a)
+}
+
+func (a providersSortedByName) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a providersSortedByName) Less(i, j int) bool {
+	return a[i].Name < a[j].Name || (a[i].Name == a[j].Name && a[i].Alias < a[j].Alias)
+}

--- a/tfconfig/test-fixtures/basics-json/basics-json.out.json
+++ b/tfconfig/test-fixtures/basics-json/basics-json.out.json
@@ -4,7 +4,7 @@
   "required_providers": {
     "null": []
   },
-  "defined_providers": [
+  "implicit_providers": [
     {"name":  "null"}
   ],
 

--- a/tfconfig/test-fixtures/basics-json/basics-json.out.json
+++ b/tfconfig/test-fixtures/basics-json/basics-json.out.json
@@ -4,6 +4,9 @@
   "required_providers": {
     "null": []
   },
+  "defined_providers": [
+    {"name":  "null"}
+  ],
 
   "variables": {
     "A": {

--- a/tfconfig/test-fixtures/basics/basics.out.json
+++ b/tfconfig/test-fixtures/basics/basics.out.json
@@ -4,7 +4,7 @@
   "required_providers": {
     "null": []
   },
-  "defined_providers": [
+  "implicit_providers": [
     {"name":  "null"}
   ],
 

--- a/tfconfig/test-fixtures/basics/basics.out.json
+++ b/tfconfig/test-fixtures/basics/basics.out.json
@@ -4,6 +4,9 @@
   "required_providers": {
     "null": []
   },
+  "defined_providers": [
+    {"name":  "null"}
+  ],
 
   "variables": {
     "A": {

--- a/tfconfig/test-fixtures/data-resources/data-resources.out.json
+++ b/tfconfig/test-fixtures/data-resources/data-resources.out.json
@@ -5,7 +5,7 @@
         "external": [],
         "notexternal": []
     },
-    "defined_providers": [
+    "implicit_providers": [
         {"name": "external"},
         {"name": "notexternal"}
     ],

--- a/tfconfig/test-fixtures/data-resources/data-resources.out.json
+++ b/tfconfig/test-fixtures/data-resources/data-resources.out.json
@@ -5,6 +5,10 @@
         "external": [],
         "notexternal": []
     },
+    "defined_providers": [
+        {"name": "external"},
+        {"name": "notexternal"}
+    ],
 
     "variables": {},
     "outputs": {},

--- a/tfconfig/test-fixtures/legacy-block-labels/legacy-block-labels.out.json
+++ b/tfconfig/test-fixtures/legacy-block-labels/legacy-block-labels.out.json
@@ -10,9 +10,11 @@
     },
     "defined_providers": [
         {"name": "aws"},
-        {"name": "external"},
-        {"name": "notnull", "alias": "baz"},
         {"name": "noversion"}
+    ],
+    "implicit_providers": [
+        {"name": "external"},
+        {"name": "notnull", "alias": "baz"}
     ],
 
     "variables": {

--- a/tfconfig/test-fixtures/legacy-block-labels/legacy-block-labels.out.json
+++ b/tfconfig/test-fixtures/legacy-block-labels/legacy-block-labels.out.json
@@ -8,6 +8,12 @@
         "external": [],
         "noversion": []
     },
+    "defined_providers": [
+        {"name": "aws"},
+        {"name": "external"},
+        {"name": "notnull", "alias": "baz"},
+        {"name": "noversion"}
+    ],
 
     "variables": {
         "foo": {

--- a/tfconfig/test-fixtures/overrides/overrides.out.json
+++ b/tfconfig/test-fixtures/overrides/overrides.out.json
@@ -4,7 +4,7 @@
   "required_providers": {
     "null": []
   },
-  "defined_providers": [
+  "implicit_providers": [
     {"name": "null"}
   ],
 

--- a/tfconfig/test-fixtures/overrides/overrides.out.json
+++ b/tfconfig/test-fixtures/overrides/overrides.out.json
@@ -4,6 +4,9 @@
   "required_providers": {
     "null": []
   },
+  "defined_providers": [
+    {"name": "null"}
+  ],
 
   "variables": {
     "A": {

--- a/tfconfig/test-fixtures/provider-configs/provider-configs.out.json
+++ b/tfconfig/test-fixtures/provider-configs/provider-configs.out.json
@@ -6,6 +6,11 @@
         "bar": ["1.0.0", "1.1.0"],
         "baz": ["2.0.0"]
     },
+    "defined_providers": [
+        {"name": "bar"},
+        {"name": "bar", "alias": "fizzbuzz"},
+        {"name": "foo"}
+    ],
 
     "variables": {},
     "outputs": {},
@@ -20,7 +25,7 @@
             },
             "pos": {
                 "filename": "test-fixtures/provider-configs/provider-configs.tf",
-                "line": 10
+                "line": 14
             }
         }
     },

--- a/tfconfig/test-fixtures/provider-configs/provider-configs.tf
+++ b/tfconfig/test-fixtures/provider-configs/provider-configs.tf
@@ -5,6 +5,10 @@ provider "bar" {
   version = "1.0.0"
 }
 
+provider "bar" {
+  alias = "fizzbuzz"
+}
+
 # Ensure that an implied dependency doesn't overwrite the explicit dependency
 # on version 1.0.0.
 resource "bar_bar" "bar" {

--- a/tfconfig/test-fixtures/resource-provider-alias/resource-provider-alias.out.json
+++ b/tfconfig/test-fixtures/resource-provider-alias/resource-provider-alias.out.json
@@ -5,7 +5,7 @@
         "aws": [],
         "notaws": []
     },
-    "defined_providers": [
+    "implicit_providers": [
         {"name": "aws"},
         {"name": "aws", "alias": "aliased"},
         {"name": "notaws"}

--- a/tfconfig/test-fixtures/resource-provider-alias/resource-provider-alias.out.json
+++ b/tfconfig/test-fixtures/resource-provider-alias/resource-provider-alias.out.json
@@ -5,6 +5,11 @@
         "aws": [],
         "notaws": []
     },
+    "defined_providers": [
+        {"name": "aws"},
+        {"name": "aws", "alias": "aliased"},
+        {"name": "notaws"}
+    ],
 
     "variables": {},
     "outputs": {},

--- a/tfconfig/test-fixtures/type-conversions/type-conversions.out.json
+++ b/tfconfig/test-fixtures/type-conversions/type-conversions.out.json
@@ -8,7 +8,9 @@
         "foo": ["true"]
     },
     "defined_providers": [
-        {"name": "foo"},
+        {"name": "foo"}
+    ],
+    "implicit_providers": [
         {"name": "true"}
     ],
 

--- a/tfconfig/test-fixtures/type-conversions/type-conversions.out.json
+++ b/tfconfig/test-fixtures/type-conversions/type-conversions.out.json
@@ -7,6 +7,10 @@
         "yep": ["true"],
         "foo": ["true"]
     },
+    "defined_providers": [
+        {"name": "foo"},
+        {"name": "true"}
+    ],
 
     "variables": {
         "foo": {

--- a/tfconfig/test-fixtures/type-errors/type-errors.out.json
+++ b/tfconfig/test-fixtures/type-errors/type-errors.out.json
@@ -81,8 +81,10 @@
         "": []
     },
     "defined_providers": [
-        {"name": ""},
         {"name": "foo"}
+    ],
+    "implicit_providers": [
+        {"name": ""}
     ],
 
     "variables": {

--- a/tfconfig/test-fixtures/type-errors/type-errors.out.json
+++ b/tfconfig/test-fixtures/type-errors/type-errors.out.json
@@ -80,6 +80,10 @@
         "foo": [],
         "": []
     },
+    "defined_providers": [
+        {"name": ""},
+        {"name": "foo"}
+    ],
 
     "variables": {
         "foo": {


### PR DESCRIPTION
Provider name and alias information are included potentially multiple times in the `ManagedResources` and `DataResources` fields.  Provider names (but not aliases) are available via the `RequiredProviders` field.  It would be convenient to have both names and aliases available in a single place.

This PR adds the `DefinedProviders` field that is a succinct representation of the provider name/alias combinations defined by the inspected module.