### PR TITLE
contributing: terraform-config-inspect is feature complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ significantly in future versions.
 
 For that reason, **we cannot accept external PRs for this codebase that add support for additional Terraform language features**.
 
+Furthermore, we consider this package feature-complete; if there is a feature
+you wish to see added, please open a GitHub issue first so we can discuss the
+feasability and design before submitting a pull request. We are unlikely to
+accept PRs that add features without discussion first.
+
 We would be happy to review PRs to fix bugs in existing functionality or to
 improve the usability of the Go package API, however. We will be hesitant about
 any breaking changes to the API, since this library is used by a number of


### PR DESCRIPTION
Extend the contributing section of the readme to emphasize our stance that terraform-config-inspect is feature complete, and we are very cautious about introducing new features, if at all.