### PR TITLE
Merge source across required_providers blocks

### DIFF
--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -60,6 +60,20 @@ func loadModule(dir string) (*Module, Diagnostics) {
 							if _, exists := mod.RequiredProviders[name]; !exists {
 								mod.RequiredProviders[name] = req
 							} else {
+								if req.Source != "" {
+									source := mod.RequiredProviders[name].Source
+									if source != "" && source != req.Source {
+										diags = append(diags, &hcl.Diagnostic{
+											Severity: hcl.DiagWarning,
+											Summary:  "Multiple provider source attriubtes",
+											Detail:   fmt.Sprintf("Found multiple source attributes for provider %s: %q, %q", name, source, req.Source),
+											Subject:  &innerBlock.DefRange,
+										})
+									} else {
+										mod.RequiredProviders[name].Source = req.Source
+									}
+								}
+
 								mod.RequiredProviders[name].VersionConstraints = append(mod.RequiredProviders[name].VersionConstraints, req.VersionConstraints...)
 							}
 						}

--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -64,8 +64,8 @@ func loadModule(dir string) (*Module, Diagnostics) {
 									source := mod.RequiredProviders[name].Source
 									if source != "" && source != req.Source {
 										diags = append(diags, &hcl.Diagnostic{
-											Severity: hcl.DiagWarning,
-											Summary:  "Multiple provider source attriubtes",
+											Severity: hcl.DiagError,
+											Summary:  "Multiple provider source attributes",
 											Detail:   fmt.Sprintf("Found multiple source attributes for provider %s: %q, %q", name, source, req.Source),
 											Subject:  &innerBlock.DefRange,
 										})

--- a/tfconfig/load_legacy.go
+++ b/tfconfig/load_legacy.go
@@ -49,12 +49,20 @@ func loadModuleLegacyHCL(dir string) (*Module, Diagnostics) {
 			}
 
 			type TerraformBlock struct {
-				RequiredVersion string `hcl:"required_version"`
+				RequiredVersion   string      `hcl:"required_version"`
+				RequiredProviders interface{} `hcl:"required_providers"`
+				Fields            []string    `hcl:",decodedFields"`
 			}
 			var block TerraformBlock
 			err = legacyhcl.DecodeObject(&block, item.Val)
 			if err != nil {
 				return nil, diagnosticsErrorf("terraform block: %s", err)
+			}
+
+			for _, field := range block.Fields {
+				if field == "RequiredProviders" {
+					return nil, diagnosticsErrorf("terraform.required_providers must not exist")
+				}
 			}
 
 			if block.RequiredVersion != "" {

--- a/tfconfig/testdata/provider-source-invalid/provider-source-invalid.out.json
+++ b/tfconfig/testdata/provider-source-invalid/provider-source-invalid.out.json
@@ -1,0 +1,34 @@
+{
+    "path": "testdata/provider-source-invalid",
+    "required_providers": {
+        "foo": {
+            "source": "abc/foo",
+            "version_constraints": [
+                "~> 2.0.0",
+                "~> 2.1.0"
+            ]
+        },
+        "bat": {
+            "source": "abc/bat",
+            "version_constraints": [
+                "1.0.0"
+            ]
+        }
+    },
+    "variables": {},
+    "outputs": {},
+    "managed_resources": {},
+    "data_resources": {},
+    "module_calls": {},
+    "diagnostics": [
+        {
+            "severity": "warning",
+            "summary": "Multiple provider source attriubtes",
+            "detail": "Found multiple source attributes for provider bat: \"abc/bat\", \"baz/bat\"",
+            "pos": {
+                "filename": "testdata/provider-source-invalid/provider-source-invalid.tf",
+                "line": 15
+            }
+        }
+    ]
+}

--- a/tfconfig/testdata/provider-source-invalid/provider-source-invalid.out.json
+++ b/tfconfig/testdata/provider-source-invalid/provider-source-invalid.out.json
@@ -22,8 +22,8 @@
     "module_calls": {},
     "diagnostics": [
         {
-            "severity": "warning",
-            "summary": "Multiple provider source attriubtes",
+            "severity": "error",
+            "summary": "Multiple provider source attributes",
             "detail": "Found multiple source attributes for provider bat: \"abc/bat\", \"baz/bat\"",
             "pos": {
                 "filename": "testdata/provider-source-invalid/provider-source-invalid.tf",

--- a/tfconfig/testdata/provider-source-invalid/provider-source-invalid.out.md
+++ b/tfconfig/testdata/provider-source-invalid/provider-source-invalid.out.md
@@ -1,0 +1,15 @@
+
+# Module `testdata/provider-source-invalid`
+
+Provider Requirements:
+* **bat (`abc/bat`):** `1.0.0`
+* **foo (`abc/foo`):** `~> 2.0.0, ~> 2.1.0`
+
+## Problems
+
+## Warning: Multiple provider source attriubtes
+
+(at `testdata/provider-source-invalid/provider-source-invalid.tf` line 15)
+
+Found multiple source attributes for provider bat: "abc/bat", "baz/bat"
+

--- a/tfconfig/testdata/provider-source-invalid/provider-source-invalid.out.md
+++ b/tfconfig/testdata/provider-source-invalid/provider-source-invalid.out.md
@@ -7,7 +7,7 @@ Provider Requirements:
 
 ## Problems
 
-## Warning: Multiple provider source attriubtes
+## Error: Multiple provider source attributes
 
 (at `testdata/provider-source-invalid/provider-source-invalid.tf` line 15)
 

--- a/tfconfig/testdata/provider-source-invalid/provider-source-invalid.tf
+++ b/tfconfig/testdata/provider-source-invalid/provider-source-invalid.tf
@@ -1,7 +1,11 @@
 terraform {
   required_providers {
-    foo = "2.0.0"
+    foo = {
+      source = "abc/foo"
+      version = "~> 2.0.0"
+    }
     bat = {
+      source = "abc/bat"
       version = "1.0.0"
     }
   }
@@ -9,6 +13,9 @@ terraform {
 
 terraform {
   required_providers {
+    foo = {
+      version = "~> 2.1.0"
+    }
     bat = {
       source  = "baz/bat"
     }


### PR DESCRIPTION
Rebase of #44, to keep the required providers logic in sync with Terraform. See also: hashicorp/terraform#25034

If multiple `terraform.required_providers` blocks are in the config, we already merge the version constraints for each provider. We should also merge the source attribute, and warn if there are duplicates.

Consider the following configuration:

```hcl
terraform {
  required_providers {
    foo = {
      version = "1.0.0"
    }
  }
}

terraform {
  required_providers {
    foo = {
      source = "abc/foo"
    }
  }
}
```

Before this commit, this would result in a provider requirement for `"foo"` with `version` `"1.0.0"`, but no `source`. This commit merges the source attribute from the second block into this requirement.