### PR TITLE
Allow parsing module from any filesystem

### DIFF
--- a/tfconfig/filesystem.go
+++ b/tfconfig/filesystem.go
@@ -1,0 +1,41 @@
+package tfconfig
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+// FS represents a minimal filesystem implementation
+// See io/fs.FS in http://golang.org/s/draft-iofs-design
+type FS interface {
+	Open(name string) (File, error)
+	ReadFile(name string) ([]byte, error)
+	ReadDir(dirname string) ([]os.FileInfo, error)
+}
+
+// File represents an open file in FS
+// See io/fs.File in http://golang.org/s/draft-iofs-design
+type File interface {
+	Stat() (os.FileInfo, error)
+	Read([]byte) (int, error)
+	Close() error
+}
+
+type osFs struct{}
+
+func (fs *osFs) Open(name string) (File, error) {
+	return os.Open(name)
+}
+
+func (fs *osFs) ReadFile(name string) ([]byte, error) {
+	return ioutil.ReadFile(name)
+}
+
+func (fs *osFs) ReadDir(dirname string) ([]os.FileInfo, error) {
+	return ioutil.ReadDir(dirname)
+}
+
+// NewOsFs provides a basic implementation of FS for an OS filesystem
+func NewOsFs() FS {
+	return &osFs{}
+}

--- a/tfconfig/load.go
+++ b/tfconfig/load.go
@@ -2,7 +2,6 @@ package tfconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 
@@ -12,7 +11,12 @@ import (
 // LoadModule reads the directory at the given path and attempts to interpret
 // it as a Terraform module.
 func LoadModule(dir string) (*Module, Diagnostics) {
+	return LoadModuleFromFilesystem(NewOsFs(), dir)
+}
 
+// LoadModuleFromFilesystem reads the directory at the given path
+// in the given FS and attempts to interpret it as a Terraform module
+func LoadModuleFromFilesystem(fs FS, dir string) (*Module, Diagnostics) {
 	// For broad compatibility here we actually have two separate loader
 	// codepaths. The main one uses the new HCL parser and API and is intended
 	// for configurations from Terraform 0.12 onwards (though will work for
@@ -20,10 +24,10 @@ func LoadModule(dir string) (*Module, Diagnostics) {
 	// uses the _old_ HCL implementation so we can deal with some edge-cases
 	// that are not valid in new HCL.
 
-	module, diags := loadModule(dir)
+	module, diags := loadModule(fs, dir)
 	if diags.HasErrors() {
 		// Try using the legacy HCL parser and see if we fare better.
-		legacyModule, legacyDiags := loadModuleLegacyHCL(dir)
+		legacyModule, legacyDiags := loadModuleLegacyHCL(fs, dir)
 		if !legacyDiags.HasErrors() {
 			legacyModule.init(legacyDiags)
 			return legacyModule, legacyDiags
@@ -37,7 +41,14 @@ func LoadModule(dir string) (*Module, Diagnostics) {
 // IsModuleDir checks if the given path contains terraform configuration files.
 // This allows the caller to decide how to handle directories that do not have tf files.
 func IsModuleDir(dir string) bool {
-	primaryPaths, _ := dirFiles(dir)
+	return IsModuleDirOnFilesystem(NewOsFs(), dir)
+}
+
+// IsModuleDirOnFilesystem checks if the given path in the given FS contains
+// Terraform configuration files. This allows the caller to decide
+// how to handle directories that do not have tf files.
+func IsModuleDirOnFilesystem(fs FS, dir string) bool {
+	primaryPaths, _ := dirFiles(fs, dir)
 	if len(primaryPaths) == 0 {
 		return false
 	}
@@ -67,8 +78,8 @@ func (m *Module) init(diags Diagnostics) {
 	m.Diagnostics = diags
 }
 
-func dirFiles(dir string) (primary []string, diags hcl.Diagnostics) {
-	infos, err := ioutil.ReadDir(dir)
+func dirFiles(fs FS, dir string) (primary []string, diags hcl.Diagnostics) {
+	infos, err := fs.ReadDir(dir)
 	if err != nil {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,

--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -22,10 +22,20 @@ func loadModule(fs FS, dir string) (*Module, Diagnostics) {
 	for _, filename := range primaryPaths {
 		var file *hcl.File
 		var fileDiags hcl.Diagnostics
+
+		b, err := fs.ReadFile(filename)
+		if err != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Failed to read file",
+				Detail:   fmt.Sprintf("The configuration file %q could not be read.", filename),
+			})
+			continue
+		}
 		if strings.HasSuffix(filename, ".json") {
-			file, fileDiags = parser.ParseJSONFile(filename)
+			file, fileDiags = parser.ParseJSON(b, filename)
 		} else {
-			file, fileDiags = parser.ParseHCLFile(filename)
+			file, fileDiags = parser.ParseHCL(b, filename)
 		}
 		diags = append(diags, fileDiags...)
 		if file == nil {

--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -13,9 +13,9 @@ import (
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
-func loadModule(dir string) (*Module, Diagnostics) {
+func loadModule(fs FS, dir string) (*Module, Diagnostics) {
 	mod := newModule(dir)
-	primaryPaths, diags := dirFiles(dir)
+	primaryPaths, diags := dirFiles(fs, dir)
 
 	parser := hclparse.NewParser()
 

--- a/tfconfig/load_legacy.go
+++ b/tfconfig/load_legacy.go
@@ -1,14 +1,13 @@
 package tfconfig
 
 import (
-	"io/ioutil"
 	"strings"
 
 	legacyhcl "github.com/hashicorp/hcl"
 	legacyast "github.com/hashicorp/hcl/hcl/ast"
 )
 
-func loadModuleLegacyHCL(dir string) (*Module, Diagnostics) {
+func loadModuleLegacyHCL(fs FS, dir string) (*Module, Diagnostics) {
 	// This implementation is intentionally more quick-and-dirty than the
 	// main loader. In particular, it doesn't bother to keep careful track
 	// of multiple error messages because we always fall back on returning
@@ -16,13 +15,13 @@ func loadModuleLegacyHCL(dir string) (*Module, Diagnostics) {
 	// an error, and thus the errors here are not seen by the end-caller.
 	mod := newModule(dir)
 
-	primaryPaths, diags := dirFiles(dir)
+	primaryPaths, diags := dirFiles(fs, dir)
 	if diags.HasErrors() {
 		return mod, diagnosticsHCL(diags)
 	}
 
 	for _, filename := range primaryPaths {
-		src, err := ioutil.ReadFile(filename)
+		src, err := fs.ReadFile(filename)
 		if err != nil {
 			return mod, diagnosticsErrorf("Error reading %s: %s", filename, err)
 		}
@@ -320,7 +319,7 @@ func unwrapLegacyHCLObjectKeysFromJSON(item *legacyast.ObjectItem, depth int) {
 			item.Val = &legacyast.ObjectType{
 				List: &legacyast.ObjectList{
 					Items: []*legacyast.ObjectItem{
-						&legacyast.ObjectItem{
+						{
 							Keys: []*legacyast.ObjectKey{key},
 							Val:  item.Val,
 						},


### PR DESCRIPTION
## Summary

This PR introduces two new interfaces to aid with accessing configuration in any "abstract" filesystem, such as in-memory FS which is used by the language server. In LSP the server should not read files from disk if there is copy in memory (as sent by the client).

```go
type FS interface {
	Open(name string) (File, error)
	ReadFile(name string) ([]byte, error)
	ReadDir(dirname string) ([]os.FileInfo, error)
}
type File interface {
	Stat() (os.FileInfo, error)
	Read([]byte) (int, error)
	Close() error
}
```
I created interfaces pretty much identical to the ones recently published in the [Go proposal for `io/fs`](http://golang.org/s/draft-iofs-design). We don't actually need `Open` nor `File`, but I believe that adding later anything to an interface is going to be much harder than removing anything. Also assuming that the proposal goes ahead and is implemented like this, it should be fairly easy to just swap the argument types for the stdlib ones and add type aliases.

Two new functions which use this new interface were also introduced:

 - `LoadModuleFromFilesystem(fs FS, dir string) (*Module, Diagnostics)`
    - similar to `LoadModule(dir string) (*Module, Diagnostics)`
 - `IsModuleDirOnFilesystem(fs FS, dir string) bool`
    - similar to `IsModuleDir(dir string) bool`

## Backwards Compatibility for Existing Consumers

The existing interfaces should work the same as before.