### PR TITLE
tfconfig: decode provider aliases

### DIFF
--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -215,6 +215,21 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 				}
 			}
 
+			providerKey := name
+			var alias string
+			if attr, defined := content.Attributes["alias"]; defined {
+				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &alias)
+				diags = append(diags, valDiags...)
+				if !valDiags.HasErrors() && alias != "" {
+					providerKey = fmt.Sprintf("%s.%s", name, alias)
+				}
+			}
+
+			mod.ProviderConfigs[providerKey] = &ProviderConfig{
+				Name:  name,
+				Alias: alias,
+			}
+
 		case "resource", "data":
 
 			content, _, contentDiags := block.Body.PartialContent(resourceSchema)

--- a/tfconfig/module.go
+++ b/tfconfig/module.go
@@ -12,14 +12,21 @@ type Module struct {
 	RequiredCore      []string                        `json:"required_core,omitempty"`
 	RequiredProviders map[string]*ProviderRequirement `json:"required_providers"`
 
-	ManagedResources map[string]*Resource   `json:"managed_resources"`
-	DataResources    map[string]*Resource   `json:"data_resources"`
-	ModuleCalls      map[string]*ModuleCall `json:"module_calls"`
+	ProviderConfigs  map[string]*ProviderConfig `json:"provider_configs,omitempty"`
+	ManagedResources map[string]*Resource       `json:"managed_resources"`
+	DataResources    map[string]*Resource       `json:"data_resources"`
+	ModuleCalls      map[string]*ModuleCall     `json:"module_calls"`
 
 	// Diagnostics records any errors and warnings that were detected during
 	// loading, primarily for inclusion in serialized forms of the module
 	// since this slice is also returned as a second argument from LoadModule.
 	Diagnostics Diagnostics `json:"diagnostics,omitempty"`
+}
+
+// ProviderConfig represents a provider block in the configuration
+type ProviderConfig struct {
+	Name  string `json:"name"`
+	Alias string `json:"alias,omitempty"`
 }
 
 // NewModule creates new Module representing Terraform module at the given path
@@ -29,6 +36,7 @@ func NewModule(path string) *Module {
 		Variables:         make(map[string]*Variable),
 		Outputs:           make(map[string]*Output),
 		RequiredProviders: make(map[string]*ProviderRequirement),
+		ProviderConfigs:   make(map[string]*ProviderConfig),
 		ManagedResources:  make(map[string]*Resource),
 		DataResources:     make(map[string]*Resource),
 		ModuleCalls:       make(map[string]*ModuleCall),

--- a/tfconfig/testdata/legacy-block-labels/legacy-block-labels.out.json
+++ b/tfconfig/testdata/legacy-block-labels/legacy-block-labels.out.json
@@ -35,6 +35,10 @@
             }
         }
     },
+    "provider_configs": {
+        "aws": {"name": "aws"},
+        "noversion": {"name": "noversion"}
+    },
     "managed_resources": {
         "null_resource.foo": {
             "mode": "managed",

--- a/tfconfig/testdata/provider-aliases/provider-aliases.out.json
+++ b/tfconfig/testdata/provider-aliases/provider-aliases.out.json
@@ -1,0 +1,22 @@
+{
+  "path": "testdata/provider-aliases",
+  "variables": {},
+  "outputs": {},
+  "required_providers": {
+    "bar": {},
+    "baz": {},
+    "empty": {},
+    "foo": {}
+  },
+  "provider_configs": {
+    "bar.yellow": {"name": "bar", "alias": "yellow"},
+    "baz": {"name": "baz"},
+    "empty": {"name": "empty"},
+    "bar": {"name": "bar"},
+    "foo.blue": {"name": "foo", "alias": "blue"},
+    "foo.red": {"name": "foo", "alias": "red"}
+  },
+  "managed_resources": {},
+  "data_resources": {},
+  "module_calls": {}
+}

--- a/tfconfig/testdata/provider-aliases/provider-aliases.out.md
+++ b/tfconfig/testdata/provider-aliases/provider-aliases.out.md
@@ -1,0 +1,9 @@
+
+# Module `testdata/provider-aliases`
+
+Provider Requirements:
+* **bar:** (any version)
+* **baz:** (any version)
+* **empty:** (any version)
+* **foo:** (any version)
+

--- a/tfconfig/testdata/provider-aliases/provider-aliases.tf
+++ b/tfconfig/testdata/provider-aliases/provider-aliases.tf
@@ -1,0 +1,21 @@
+provider "foo" {
+  alias = "blue"
+}
+
+provider "foo" {
+  alias = "red"
+}
+
+provider "bar" {
+}
+
+provider "bar" {
+  alias = "yellow"
+}
+
+provider "baz" {
+}
+
+provider "empty" {
+  alias = ""
+}

--- a/tfconfig/testdata/provider-configs/provider-configs.out.json
+++ b/tfconfig/testdata/provider-configs/provider-configs.out.json
@@ -16,6 +16,10 @@
     },
     "variables": {},
     "outputs": {},
+    "provider_configs": {
+        "foo": {"name": "foo"},
+        "bar": {"name": "bar"}
+    },
     "managed_resources": {
         "bar_bar.bar": {
             "mode": "managed",

--- a/tfconfig/testdata/type-conversions/type-conversions.out.json
+++ b/tfconfig/testdata/type-conversions/type-conversions.out.json
@@ -39,6 +39,9 @@
             }
         }
     },
+    "provider_configs": {
+        "foo": {"name": "foo"}
+    },
     "managed_resources": {
         "foo.foo": {
             "mode": "managed",

--- a/tfconfig/testdata/type-errors/type-errors.out.json
+++ b/tfconfig/testdata/type-errors/type-errors.out.json
@@ -99,6 +99,9 @@
             }
         }
     },
+    "provider_configs": {
+        "foo": {"name": "foo"}
+    },
     "managed_resources": {
         "foo.foo": {
             "mode": "managed",


### PR DESCRIPTION
The first commit is just https://github.com/hashicorp/terraform-config-inspect/pull/53 and it's part of the PR because it would otherwise be likely difficult to merge the two, given the overlap. I can rebase this PR when #53 is merged.

--- 

This patch introduces new field for `Module` - `ProviderConfigs`, which is a map where key is the provider "identification" (e.g. `aws.west` or just `aws` if no alias is present).

The use case I have in mind for this is the Terraform language server, where we need to know how to complete `resource` or `data` blocks. Aliases technically do not affect the schema, esp. because there's only ever 1 version of a provider (= 1 version of the schema), but knowing all the aliases aids the decoder in quick map lookups where key is a combination of the 1st label (resource/data source type) and `provider` key (if any), otherwise we'd have to range over the whole map of all resources/data sources of all providers.

I'm assuming this doesn't pose any issue from compatibility perspective since provider aliases have been around for a while and the block schema even already contains that attribute, it was just never used:

https://github.com/hashicorp/terraform-config-inspect/blob/c481b8bfa41ea9dca417c2a8a98fd21bd0399e14/tfconfig/schema.go#L53-L62