### PR TITLE
Support the sensitive attribute on outputs (#55)

### DIFF
--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -195,6 +195,13 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 				o.Description = description
 			}
 
+			if attr, defined := content.Attributes["sensitive"]; defined {
+				var sensitive bool
+				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &sensitive)
+				diags = append(diags, valDiags...)
+				o.Sensitive = sensitive
+			}
+
 		case "provider":
 
 			content, _, contentDiags := block.Body.PartialContent(providerConfigSchema)

--- a/tfconfig/load_legacy.go
+++ b/tfconfig/load_legacy.go
@@ -124,6 +124,7 @@ func loadModuleLegacyHCL(fs FS, dir string) (*Module, Diagnostics) {
 			outputs = outputs.Children()
 			type OutputBlock struct {
 				Description string
+				Sensitive   bool
 			}
 
 			for _, item := range outputs.Items {
@@ -144,6 +145,7 @@ func loadModuleLegacyHCL(fs FS, dir string) (*Module, Diagnostics) {
 				o := &Output{
 					Name:        name,
 					Description: block.Description,
+					Sensitive:   block.Sensitive,
 					Pos:         sourcePosLegacyHCL(item.Pos(), filename),
 				}
 				if _, exists := mod.Outputs[name]; exists {

--- a/tfconfig/output.go
+++ b/tfconfig/output.go
@@ -2,8 +2,8 @@ package tfconfig
 
 // Output represents a single output from a Terraform module.
 type Output struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-
-	Pos SourcePos `json:"pos"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	Sensitive   bool      `json:"sensitive,omitempty"`
+	Pos         SourcePos `json:"pos"`
 }

--- a/tfconfig/schema.go
+++ b/tfconfig/schema.go
@@ -80,6 +80,9 @@ var outputSchema = &hcl.BodySchema{
 		{
 			Name: "description",
 		},
+		{
+			Name: "sensitive",
+		},
 	},
 }
 

--- a/tfconfig/testdata/basics-json/basics-json.out.json
+++ b/tfconfig/testdata/basics-json/basics-json.out.json
@@ -39,6 +39,15 @@
         "filename": "testdata/basics-json/basics.tf.json",
         "line": 14
       }
+    },
+    "C": {
+      "name": "C",
+      "description": "C is sensitive B",
+      "sensitive": true,
+      "pos": {
+        "filename": "testdata/basics-json/basics.tf.json",
+        "line": 18
+      }
     }
   },
   "managed_resources": {
@@ -51,7 +60,7 @@
       },
       "pos": {
         "filename": "testdata/basics-json/basics.tf.json",
-        "line": 21
+        "line": 26
       }
     },
     "null_resource.B": {
@@ -63,7 +72,7 @@
       },
       "pos": {
         "filename": "testdata/basics-json/basics.tf.json",
-        "line": 22
+        "line": 27
       }
     }
   },

--- a/tfconfig/testdata/basics-json/basics.tf.json
+++ b/tfconfig/testdata/basics-json/basics.tf.json
@@ -14,6 +14,11 @@
         "B": {
             "description": "I am B",
             "value": "${var.A}"
+        },
+        "C": {
+            "description": "C is sensitive B",
+            "value": "${var.B}",
+            "sensitive": true
         }
     },
     "resource": {

--- a/tfconfig/testdata/basics/basics.out.json
+++ b/tfconfig/testdata/basics/basics.out.json
@@ -22,6 +22,16 @@
         "filename": "testdata/basics/basics.tf",
         "line": 5
       }
+    },
+    "C": {
+      "name": "C",
+      "description": "The C variable",
+      "default": null,
+      "required": true,
+      "pos": {
+        "filename": "testdata/basics/basics.tf",
+        "line": 9
+      }
     }
   },
   "outputs": {
@@ -29,7 +39,7 @@
       "name": "A",
       "pos": {
         "filename": "testdata/basics/basics.tf",
-        "line": 9
+        "line": 13
       }
     },
     "B": {
@@ -37,7 +47,16 @@
       "description": "I am B",
       "pos": {
         "filename": "testdata/basics/basics.tf",
-        "line": 13
+        "line": 17
+      }
+    },
+    "C": {
+      "name": "C",
+      "description": "C is sensitive",
+      "sensitive": true,
+      "pos": {
+        "filename": "testdata/basics/basics.tf",
+        "line": 23
       }
     }
   },
@@ -51,7 +70,7 @@
       },
       "pos": {
         "filename": "testdata/basics/basics.tf",
-        "line": 18
+        "line": 29
       }
     },
     "null_resource.B": {
@@ -63,7 +82,19 @@
       },
       "pos": {
         "filename": "testdata/basics/basics.tf",
-        "line": 19
+        "line": 30
+      }
+    },
+    "null_resource.C": {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "C",
+      "provider": {
+        "name": "null"
+      },
+      "pos": {
+        "filename": "testdata/basics/basics.tf",
+        "line": 31
       }
     }
   },

--- a/tfconfig/testdata/basics/basics.out.md
+++ b/tfconfig/testdata/basics/basics.out.md
@@ -7,12 +7,15 @@ Provider Requirements:
 ## Input Variables
 * `A` (default `"A default"`)
 * `B` (required): The B variable
+* `C` (required): The C variable
 
 ## Output Values
 * `A`
 * `B`: I am B
+* `C`: C is sensitive
 
 ## Managed Resources
 * `null_resource.A` from `null`
 * `null_resource.B` from `null`
+* `null_resource.C` from `null`
 

--- a/tfconfig/testdata/basics/basics.tf
+++ b/tfconfig/testdata/basics/basics.tf
@@ -6,6 +6,10 @@ variable "B" {
     description = "The B variable"
 }
 
+variable "C" {
+    description = "The C variable"
+}
+
 output "A" {
     value = "${var.A}"
 }
@@ -13,7 +17,15 @@ output "A" {
 output "B" {
     description = "I am B"
     value = "${var.A}"
+    sensitive = false
+}
+
+output "C" {
+    description = "C is sensitive"
+    value = "${var.C}"
+    sensitive = true
 }
 
 resource "null_resource" "A" {}
 resource "null_resource" "B" {}
+resource "null_resource" "C" {}

--- a/tfconfig/testdata/legacy-block-labels/legacy-block-labels.out.json
+++ b/tfconfig/testdata/legacy-block-labels/legacy-block-labels.out.json
@@ -29,6 +29,7 @@
         "foo": {
             "name": "foo",
             "description": "foo description",
+            "sensitive": true,
             "pos": {
                 "filename": "testdata/legacy-block-labels/legacy-block-labels.tf",
                 "line": 35
@@ -46,7 +47,7 @@
             },
             "pos": {
                 "filename": "testdata/legacy-block-labels/legacy-block-labels.tf",
-                "line": 40
+                "line": 41
             }
         }
     },
@@ -60,7 +61,7 @@
             },
             "pos": {
                 "filename": "testdata/legacy-block-labels/legacy-block-labels.tf",
-                "line": 45
+                "line": 46
             }
         }
     },
@@ -71,7 +72,7 @@
             "version": "1.2.3",
             "pos": {
                 "filename": "testdata/legacy-block-labels/legacy-block-labels.tf",
-                "line": 49
+                "line": 50
             }
         }
     }

--- a/tfconfig/testdata/legacy-block-labels/legacy-block-labels.tf
+++ b/tfconfig/testdata/legacy-block-labels/legacy-block-labels.tf
@@ -34,6 +34,7 @@ variable foo {
 
 output foo {
   description = "foo description"
+  sensitive = true
   ignored = 1
 }
 

--- a/tfconfig/testdata/type-errors/type-errors.out.json
+++ b/tfconfig/testdata/type-errors/type-errors.out.json
@@ -22,10 +22,10 @@
         {
             "severity": "error",
             "summary": "Unsuitable value type",
-            "detail": "Unsuitable value: string required",
+            "detail": "Unsuitable value: a bool is required",
             "pos": {
                 "filename": "testdata/type-errors/type-errors.tf",
-                "line": 11
+                "line": 8
             }
         },
         {
@@ -43,7 +43,16 @@
             "detail": "Unsuitable value: string required",
             "pos": {
                 "filename": "testdata/type-errors/type-errors.tf",
-                "line": 16
+                "line": 13
+            }
+        },
+        {
+            "severity": "error",
+            "summary": "Unsuitable value type",
+            "detail": "Unsuitable value: string required",
+            "pos": {
+                "filename": "testdata/type-errors/type-errors.tf",
+                "line": 17
             }
         },
         {
@@ -52,7 +61,7 @@
             "detail": "Provider argument requires a provider name followed by an optional alias, like \"aws.foo\".",
             "pos": {
                 "filename": "testdata/type-errors/type-errors.tf",
-                "line": 20
+                "line": 21
             }
         },
         {
@@ -61,7 +70,7 @@
             "detail": "Unsuitable value: string required",
             "pos": {
                 "filename": "testdata/type-errors/type-errors.tf",
-                "line": 24
+                "line": 25
             }
         },
         {
@@ -70,7 +79,7 @@
             "detail": "Unsuitable value: string required",
             "pos": {
                 "filename": "testdata/type-errors/type-errors.tf",
-                "line": 26
+                "line": 27
             }
         }
     ],
@@ -109,7 +118,7 @@
             },
             "pos": {
                 "filename": "testdata/type-errors/type-errors.tf",
-                "line": 19
+                "line": 20
             }
         }
     },
@@ -120,7 +129,7 @@
             "source": "",
             "pos": {
                 "filename": "testdata/type-errors/type-errors.tf",
-                "line": 10
+                "line": 11
             }
         }
     }

--- a/tfconfig/testdata/type-errors/type-errors.out.md
+++ b/tfconfig/testdata/type-errors/type-errors.out.md
@@ -33,9 +33,9 @@ Unsuitable value: string required
 
 ## Error: Unsuitable value type
 
-(at `testdata/type-errors/type-errors.tf` line 11)
+(at `testdata/type-errors/type-errors.tf` line 8)
 
-Unsuitable value: string required
+Unsuitable value: a bool is required
 
 ## Error: Unsuitable value type
 
@@ -45,25 +45,31 @@ Unsuitable value: string required
 
 ## Error: Unsuitable value type
 
-(at `testdata/type-errors/type-errors.tf` line 16)
+(at `testdata/type-errors/type-errors.tf` line 13)
+
+Unsuitable value: string required
+
+## Error: Unsuitable value type
+
+(at `testdata/type-errors/type-errors.tf` line 17)
 
 Unsuitable value: string required
 
 ## Error: Invalid provider reference
 
-(at `testdata/type-errors/type-errors.tf` line 20)
+(at `testdata/type-errors/type-errors.tf` line 21)
 
 Provider argument requires a provider name followed by an optional alias, like "aws.foo".
 
 ## Error: Unsuitable value type
 
-(at `testdata/type-errors/type-errors.tf` line 24)
+(at `testdata/type-errors/type-errors.tf` line 25)
 
 Unsuitable value: string required
 
 ## Error: Unsuitable value type
 
-(at `testdata/type-errors/type-errors.tf` line 26)
+(at `testdata/type-errors/type-errors.tf` line 27)
 
 Unsuitable value: string required
 

--- a/tfconfig/testdata/type-errors/type-errors.tf
+++ b/tfconfig/testdata/type-errors/type-errors.tf
@@ -5,6 +5,7 @@ variable "foo" {
 
 output "foo" {
   description = ["blah"]
+  sensitive   = "blah"
 }
 
 module "foo" {


### PR DESCRIPTION
If sensitive is not specified or is false it will not be present in the Output object as per omitempty behavior.