### PR TITLE
Expose configuration_aliases from required_providers

### DIFF
--- a/tfconfig/testdata/provider-aliases-json/provider-aliases-json.out.json
+++ b/tfconfig/testdata/provider-aliases-json/provider-aliases-json.out.json
@@ -1,5 +1,5 @@
 {
-  "path": "testdata/provider-aliases",
+  "path": "testdata/provider-aliases-json",
   "variables": {},
   "outputs": {},
   "required_providers": {

--- a/tfconfig/testdata/provider-aliases-json/provider-aliases-json.out.md
+++ b/tfconfig/testdata/provider-aliases-json/provider-aliases-json.out.md
@@ -1,0 +1,10 @@
+
+# Module `testdata/provider-aliases-json`
+
+Provider Requirements:
+* **bar:** (any version)
+* **baz:** (any version)
+* **bleep:** (any version)
+* **empty:** (any version)
+* **foo:** (any version)
+

--- a/tfconfig/testdata/provider-aliases-json/provider-aliases-json.tf.json
+++ b/tfconfig/testdata/provider-aliases-json/provider-aliases-json.tf.json
@@ -1,0 +1,35 @@
+{
+  "terraform": {
+    "required_providers": {
+      "bleep": {
+        "configuration_aliases": [
+          "bleep.bloop"
+        ]
+      }
+    }
+  },
+  "provider": {
+    "foo": [
+      {
+        "alias": "blue"
+      },
+      {
+        "alias": "red"
+      }
+    ],
+    "bar": [
+      {},
+      {
+        "alias": "yellow"
+      }
+    ],
+    "baz": [
+      {}
+    ],
+    "empty": [
+      {
+        "alias": ""
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This unblocks https://github.com/hashicorp/terraform-schema/pull/26 which in turn allows us to support 0.15 configurations and interpret them accurately.

--- 

I know that aliases basically don't play any role when it comes to schema (which is what LS cares about), the local name should suffice. However we made a decision in the design of some LS components early on (admittedly with some tradeoffs) to perform exact match on the `provider` fields in resources and data source, as opposed to match just first step of the traversal.

That decision is not necessarily set in stone, but it would require quite a significant redesign and we'd probably just end up with different trade-offs.