### PR TITLE
Fix panic when calling ParseHCL

### DIFF
--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -62,6 +62,10 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 		switch block.Type {
 
 		case "terraform":
+
+			if mod.RequiredCore == nil  || mod.RequiredProviders == nil  {
+				break
+			}
 			content, _, contentDiags := block.Body.PartialContent(terraformBlockSchema)
 			diags = append(diags, contentDiags...)
 
@@ -104,6 +108,10 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 			}
 
 		case "variable":
+
+			if mod.Variables == nil {
+				break
+			}
 			content, _, contentDiags := block.Body.PartialContent(variableSchema)
 			diags = append(diags, contentDiags...)
 
@@ -177,6 +185,9 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 
 		case "output":
 
+			if mod.Outputs == nil {
+				break
+			}
 			content, _, contentDiags := block.Body.PartialContent(outputSchema)
 			diags = append(diags, contentDiags...)
 
@@ -204,6 +215,9 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 
 		case "provider":
 
+			if mod.RequiredProviders == nil || mod.ProviderConfigs == nil {
+				break
+			}
 			content, _, contentDiags := block.Body.PartialContent(providerConfigSchema)
 			diags = append(diags, contentDiags...)
 
@@ -238,6 +252,10 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 			}
 
 		case "resource", "data":
+
+			if mod.ManagedResources == nil || mod.DataResources == nil {
+				break
+			}
 
 			content, _, contentDiags := block.Body.PartialContent(resourceSchema)
 			diags = append(diags, contentDiags...)
@@ -317,6 +335,10 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 			}
 
 		case "module":
+
+			if mod.ModuleCalls == nil {
+				break
+			}
 
 			content, _, contentDiags := block.Body.PartialContent(moduleCallSchema)
 			diags = append(diags, contentDiags...)


### PR DESCRIPTION
In function ParseHCL, not all fields of tfconfig.Module is checked,
so panic will happen.

Fix #https://github.com/hashicorp/terraform-config-inspect/issues/61