### PR TITLE
Fix CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,9 @@
 version: 2.1
 
-orbs:
-  go: circleci/go@1.1.1
-
 jobs:
   test:
-    executor: 
-      name: go/default
-      tag: << parameters.go-version >>
+    docker:
+      - image: circleci/golang:<< parameters.go-version >>
     parameters:
       go-version:
         type: string
@@ -16,9 +12,6 @@ jobs:
     working_directory: /go/src/github.com/hashicorp/terraform-config-inspect
     steps:
       - checkout
-      - go/load-cache
-      - go/mod-download
-      - go/save-cache
       - run: go test
       - run: go install .
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,5 +21,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              go-version: ["1.11.13", "1.13.4"]
+              go-version: ["1.17.3", "1.13.4"]
           name: test-go-<< matrix.go-version >>


### PR DESCRIPTION
Something is causing CI failures with the 1.11.13 build during `go mod download`. I've tried upgrading the CircleCI orb, and switching to an explicit `circleci/go` Docker image, and neither works.

This PR now also drops the 1.11.13 build and replaces it with a (current) 1.17.3. I can't see any reason why we're required to maintain compatibility with Go 1.11 indefinitely, so I believe this change is reasonable.