### PR TITLE
update circle config and docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,19 @@
 version: 2.1
 
+executors:
+  go:
+    docker:
+      - image: docker.mirror.hashicorp.services/cimg/go:1.17
+
 jobs:
   test:
-    docker:
-      - image: circleci/golang:<< parameters.go-version >>
-    parameters:
-      go-version:
-        type: string
-    environment:
-      GO111MODULE: "on"
-    working_directory: /go/src/github.com/hashicorp/terraform-config-inspect
+    executor:
+      name: go
     steps:
       - checkout
       - run: go test
-      - run: go install .
 
 workflows:
   terraform-config-inspect:
     jobs:
-      - test:
-          matrix:
-            parameters:
-              go-version: ["1.17.3", "1.13.4"]
-          name: test-go-<< matrix.go-version >>
+      - test


### PR DESCRIPTION
Drop go1.13 since that is no longer supported, leaving only the currently supported major go version.
Update the circle config and use the hashi mirror for the go docker image.