### PR TITLE
Parse variable validation

### DIFF
--- a/tfconfig/schema.go
+++ b/tfconfig/schema.go
@@ -76,6 +76,23 @@ var variableSchema = &hcl.BodySchema{
 			Name: "sensitive",
 		},
 	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type:       "validation",
+			LabelNames: nil,
+		},
+	},
+}
+
+var variableValidationSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name: "condition",
+		},
+		{
+			Name: "error_message",
+		},
+	},
 }
 
 var outputSchema = &hcl.BodySchema{

--- a/tfconfig/testdata/variable-validation/variable-validation.out.json
+++ b/tfconfig/testdata/variable-validation/variable-validation.out.json
@@ -1,0 +1,49 @@
+{
+    "path": "testdata/variable-validation",
+    "required_providers": {
+      "null": {}
+    },
+    "variables": {
+      "A": {
+        "name": "A",
+        "default": "A default",
+        "required": false,
+        "pos": {
+          "filename": "testdata/variable-validation/variable-validation.tf",
+          "line": 1
+        }
+      },
+      "B": {
+        "name": "B",
+        "default": "B default",
+        "required": false,
+        "pos": {
+          "filename": "testdata/variable-validation/variable-validation.tf",
+          "line": 5
+        },
+        "validations": [
+            {
+                "error_message": "B error message"
+            }
+        ]
+      }
+    },
+    "outputs": {},
+    "managed_resources": {
+      "null_resource.A": {
+        "mode": "managed",
+        "type": "null_resource",
+        "name": "A",
+        "provider": {
+          "name": "null"
+        },
+        "pos": {
+          "filename": "testdata/variable-validation/variable-validation.tf",
+          "line": 13
+        }
+      }
+    },
+    "data_resources": {},
+    "module_calls": {}
+  }
+  

--- a/tfconfig/testdata/variable-validation/variable-validation.out.md
+++ b/tfconfig/testdata/variable-validation/variable-validation.out.md
@@ -1,0 +1,13 @@
+
+# Module `testdata/variable-validation`
+
+Provider Requirements:
+* **null:** (any version)
+
+## Input Variables
+* `A` (default `"A default"`)
+* `B` (default `"B default"`)
+
+## Managed Resources
+* `null_resource.A` from `null`
+

--- a/tfconfig/testdata/variable-validation/variable-validation.tf
+++ b/tfconfig/testdata/variable-validation/variable-validation.tf
@@ -1,0 +1,13 @@
+variable "A" {
+    default = "A default"
+}
+
+variable "B" {
+    default = "B default"
+    validation {
+      condition = true
+      error_message = "B error message"
+    }
+}
+
+resource "null_resource" "A" {}

--- a/tfconfig/variable.go
+++ b/tfconfig/variable.go
@@ -1,5 +1,7 @@
 package tfconfig
 
+import "github.com/hashicorp/hcl/v2"
+
 // Variable represents a single variable from a Terraform module.
 type Variable struct {
 	Name        string `json:"name"`
@@ -14,5 +16,26 @@ type Variable struct {
 	Required  bool        `json:"required"`
 	Sensitive bool        `json:"sensitive,omitempty"`
 
+	Validations []VariableValidation `json:"validations,omitempty"`
+
 	Pos SourcePos `json:"pos"`
+}
+
+// VariableValidation represents a configuration-defined validation rule
+// for a particular input variable, given as a "validation" block inside
+// a "variable" block.
+type VariableValidation struct {
+	// Condition is an expression that refers to the variable being tested
+	// and contains no other references. The expression must return true
+	// to indicate that the value is valid or false to indicate that it is
+	// invalid. If the expression produces an error, that's considered a bug
+	// in the module defining the validation rule, not an error in the caller.
+	Condition hcl.Expression `json:"-"`
+
+	// ErrorMessage is one or more full sentences, which would need to be in
+	// English for consistency with the rest of the error message output but
+	// can in practice be in any language as long as it ends with a period.
+	// The message should describe what is required for the condition to return
+	// true in a way that would make sense to a caller of the module.
+	ErrorMessage string `json:"error_message"`
 }


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-config-inspect/issues/73.

Adds variable validation parsing.

Currently omits the `condition` property from JSON output, but happy to accept suggestions!

The comments on `VariableValidation` are taken from: 
https://github.com/hashicorp/terraform/blob/b91d9435ea9d4e8f1708a7092cd7d20d26f15e03/internal/configs/named_values.go#L311-L330