### PR TITLE
Export functions for processing module files

### DIFF
--- a/tfconfig/load.go
+++ b/tfconfig/load.go
@@ -55,6 +55,13 @@ func IsModuleDirOnFilesystem(fs FS, dir string) bool {
 	return true
 }
 
+// IsOverrideFile checks if the given filename is an override file.
+func IsOverrideFile(baseFilename string) bool {
+	ext := fileExt(baseFilename)
+	baseName := baseFilename[:len(baseFilename)-len(ext)] // strip extension
+	return baseName == "override" || strings.HasSuffix(baseName, "_override")
+}
+
 func (m *Module) init(diags Diagnostics) {
 	// Fill in any additional provider requirements that are implied by
 	// resource configurations, to avoid the caller from needing to apply
@@ -102,11 +109,8 @@ func dirFiles(fs FS, dir string) (primary []string, diags hcl.Diagnostics) {
 			continue
 		}
 
-		baseName := name[:len(name)-len(ext)] // strip extension
-		isOverride := baseName == "override" || strings.HasSuffix(baseName, "_override")
-
 		fullPath := filepath.Join(dir, name)
-		if isOverride {
+		if IsOverrideFile(name) {
 			override = append(override, fullPath)
 		} else {
 			primary = append(primary, fullPath)

--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -61,11 +61,11 @@ func LoadModuleFilesFromFileSystem(fs FS, dir string, loadModuleFile LoadModuleF
 
 func loadModule(fs FS, dir string) (*Module, Diagnostics) {
 	mod := NewModule(dir)
-	diags := diagnosticsHCL(LoadModuleFilesFromFileSystem(fs, dir, func(file *hcl.File, _ string) hcl.Diagnostics {
+	diags := LoadModuleFilesFromFileSystem(fs, dir, func(file *hcl.File, _ string) hcl.Diagnostics {
 		return LoadModuleFromFile(file, mod)
-	}))
+	})
 
-	return mod, diags
+	return mod, diagnosticsHCL(diags)
 }
 
 // LoadModuleFromFile reads given file, interprets it and stores in given Module


### PR DESCRIPTION
Hi,

Currently it not possible to easily inspect a modules configuration if you need to customise file inspection. The changes in this PR only export existing functionality. If you want to perform any custom inspection of module files currently you'd need to re-write, copy/paste or fork the repo, these changes allow you to quickly start processing a module as you need.

I'm not sure if it's within the intended scope of this project, but I think it would be useful. Some of the existing PRs and issues could be solved by using these functions to augment the output of the `LoadModule*()` functions.

Exports the following functions to allow callers to inspect the files of a terraform module:
1. `LoadModuleFiles`: Invokes a callback function for each file in a module 
2. `LoadModuleFilesFromFileSystem`: As above, with additional `FS` arg
3. `IsOverrideFile`: Uses filename to determines if a file is an override file

Let me know if you have questions. Feel free to rename the functions.

Thanks, Adam.
