### PR TITLE
Complete the GHA migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,9 +8,12 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   unit_tests:
-    name: "Unit Tests on ${{ matrix.target }}"
+    name: "unit tests"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fixes https://github.com/hashicorp/GHA-migration/issues/81

- Set up minimal permissions on the existing GHA workflows
- Fix the name of the unit test job, we don't have any matrices defined in the workflow
- Configure dependabot to scan for vulns in GHA workflows