### PR TITLE
Document need to add GOPATH/bin to PATH to run CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The primary way to use this repository is as a Go library, but as a convenience
 it also contains a CLI tool called `terraform-config-inspect`, installed
 automatically by the `go get` command above, that allows viewing module
 information in either a Markdown-like format or in JSON format.
+You need to [explicitly add `$GOPATH/bin` to your `PATH`](https://github.com/actions/setup-go/issues/27#issuecomment-549102955)
+to run this CLI without qualifying the full path.
 
 ```sh
 $ terraform-config-inspect path/to/module


### PR DESCRIPTION
Not being a Go developer, it caught me off guard that this wasn't added to the PATH by default, so I was wondering whether the CLI had been correctly installed. Explicitly adding it to the PATH as indicated by the linked comment fixed the issue.