### PR TITLE
Adds `--stacks` flag to terraform-config-inspect CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,17 @@ be lower in older language versions.
 The primary way to use this repository is as a Go library, but as a convenience
 it also contains a CLI tool called `terraform-config-inspect`, installed
 automatically by the `go get` command above, that allows viewing module
-information in either a Markdown-like format or in JSON format.
+information in either a Markdown-like format or in JSON format. It also 
+supports parsing Terraform stacks using the `--stack` flag.
 
 ```sh
 $ terraform-config-inspect path/to/module
+```
+
+For Terraform stacks:
+
+```sh
+$ terraform-config-inspect --stack path/to/stack
 ```
 
 ```markdown
@@ -136,6 +143,85 @@ $ terraform-config-inspect --json path/to/module
   },
   "data_resources": {},
   "module_calls": {}
+}
+```
+
+For Terraform stacks, you can use the `--stack` flag:
+
+```sh
+$ terraform-config-inspect --stack path/to/stack
+```
+
+```markdown
+# Terraform Stack: path/to/stack
+
+## Variables
+
+- **regions** (set(string))
+- **identity_token** (string)
+- **default_tags** (map(string)): A map of default tags to apply to all AWS resources
+
+## Outputs
+
+- **lambda_urls**: URLs to invoke lambda functions
+
+## Components
+
+- **s3** (source: `./s3`)
+- **lambda** (source: `./lambda`)
+- **api_gateway** (source: `./api-gateway`)
+
+## Required Providers
+
+- **aws** (source: `hashicorp/aws`)
+- **archive** (source: `hashicorp/archive`)
+```
+
+```sh
+$ terraform-config-inspect --stack --json path/to/stack
+```
+
+```json
+{
+  "path": "path/to/stack",
+  "variables": {
+    "regions": {
+      "name": "regions",
+      "type": "set(string)",
+      "default": null,
+      "required": true,
+      "pos": {
+        "filename": "path/to/stack/variables.tfstack.hcl",
+        "line": 4
+      }
+    }
+  },
+  "outputs": {
+    "lambda_urls": {
+      "name": "lambda_urls",
+      "description": "URLs to invoke lambda functions",
+      "pos": {
+        "filename": "path/to/stack/outputs.tfcomponent.hcl",
+        "line": 1
+      },
+      "type": "list(string)"
+    }
+  },
+  "required_providers": {
+    "aws": {
+      "source": "hashicorp/aws"
+    }
+  },
+  "components": {
+    "s3": {
+      "name": "s3",
+      "source": "./s3",
+      "pos": {
+        "filename": "path/to/stack/components.tfcomponent.hcl",
+        "line": 4
+      }
+    }
+  }
 }
 ```
 

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 
 	if *parseStack {
 		stack, diags := tfconfig.LoadStack(dir)
+		stack.Diagnostics = diags
 
 		if *showJSON {
 			showStackJSON(stack)
@@ -34,7 +35,7 @@ func main() {
 			showStackMarkdown(stack)
 		}
 
-		if diags.HasErrors() {
+		if stack.Diagnostics.HasErrors() {
 			os.Exit(1)
 		}
 	} else {
@@ -126,6 +127,27 @@ func showStackMarkdown(stack *tfconfig.Stack) {
 				fmt.Printf(" version: %s", provider.VersionConstraints[0])
 			}
 			fmt.Printf("\n")
+		}
+	}
+
+	if len(stack.Diagnostics) > 0 {
+		fmt.Printf("## Problems\n\n")
+		for _, diag := range stack.Diagnostics {
+			severity := ""
+			switch diag.Severity {
+			case tfconfig.DiagError:
+				severity = "Error: "
+			case tfconfig.DiagWarning:
+				severity = "Warning: "
+			}
+			fmt.Printf("## %s%s", severity, diag.Summary)
+			if diag.Pos != nil {
+				fmt.Printf("\n\n(at `%s` line %d)", diag.Pos.Filename, diag.Pos.Line)
+			}
+			if diag.Detail != "" {
+				fmt.Printf("\n\n%s", diag.Detail)
+			}
+			fmt.Printf("\n\n")
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 var showJSON = flag.Bool("json", false, "produce JSON-formatted output")
+var parseStack = flag.Bool("stack", false, "parse as Terraform stack instead of module")
 
 func main() {
 	flag.Parse()
@@ -24,16 +25,30 @@ func main() {
 		dir = "."
 	}
 
-	module, _ := tfconfig.LoadModule(dir)
+	if *parseStack {
+		stack, diags := tfconfig.LoadStack(dir)
 
-	if *showJSON {
-		showModuleJSON(module)
+		if *showJSON {
+			showStackJSON(stack)
+		} else {
+			showStackMarkdown(stack)
+		}
+
+		if diags.HasErrors() {
+			os.Exit(1)
+		}
 	} else {
-		showModuleMarkdown(module)
-	}
+		module, _ := tfconfig.LoadModule(dir)
 
-	if module.Diagnostics.HasErrors() {
-		os.Exit(1)
+		if *showJSON {
+			showModuleJSON(module)
+		} else {
+			showModuleMarkdown(module)
+		}
+
+		if module.Diagnostics.HasErrors() {
+			os.Exit(1)
+		}
 	}
 }
 
@@ -52,5 +67,65 @@ func showModuleMarkdown(module *tfconfig.Module) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error rendering template: %s\n", err)
 		os.Exit(2)
+	}
+}
+
+func showStackJSON(stack *tfconfig.Stack) {
+	j, err := json.MarshalIndent(stack, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error producing JSON: %s\n", err)
+		os.Exit(2)
+	}
+	os.Stdout.Write(j)
+	os.Stdout.Write([]byte{'\n'})
+}
+
+func showStackMarkdown(stack *tfconfig.Stack) {
+	fmt.Printf("# Terraform Stack: %s\n\n", stack.Path)
+
+	if len(stack.Variables) > 0 {
+		fmt.Printf("## Variables\n\n")
+		for name, variable := range stack.Variables {
+			fmt.Printf("- **%s** (%s)", name, variable.Type)
+			if variable.Description != "" {
+				fmt.Printf(": %s", variable.Description)
+			}
+			fmt.Printf("\n")
+		}
+		fmt.Printf("\n")
+	}
+
+	if len(stack.Outputs) > 0 {
+		fmt.Printf("## Outputs\n\n")
+		for name, output := range stack.Outputs {
+			fmt.Printf("- **%s**", name)
+			if output.Description != "" {
+				fmt.Printf(": %s", output.Description)
+			}
+			fmt.Printf("\n")
+		}
+		fmt.Printf("\n")
+	}
+
+	if len(stack.Components) > 0 {
+		fmt.Printf("## Components\n\n")
+		for name, component := range stack.Components {
+			fmt.Printf("- **%s** (source: `%s`)\n", name, component.Source)
+		}
+		fmt.Printf("\n")
+	}
+
+	if len(stack.RequiredProviders) > 0 {
+		fmt.Printf("## Required Providers\n\n")
+		for name, provider := range stack.RequiredProviders {
+			fmt.Printf("- **%s**", name)
+			if provider.Source != "" {
+				fmt.Printf(" (source: `%s`)", provider.Source)
+			}
+			if len(provider.VersionConstraints) > 0 {
+				fmt.Printf(" version: %s", provider.VersionConstraints[0])
+			}
+			fmt.Printf("\n")
+		}
 	}
 }


### PR DESCRIPTION
This PR adds a new flag `--stack` to the CLI. It allows parsing a directory by providing a path which returns outputs, variables, components and providers either as markdown or by also adding `--json` flag as a json. It also adds diagnostics output in case of errors. Module parsing behaviour hasn't changed, it still works exactly as before. 

For testing purposes, clone the [learn-terraform-stacks-deploy](https://github.com/hashicorp-education/learn-terraform-stacks-deploy) repo, and provide its path as an argument to the CLI

```shell
go build .
./terraform-config-inspect --stack --json ../learn-terraform-stacks-deploy
```

Example output:
```json
{
  "path": "../learn-terraform-stacks-deploy",
  "variables": {
    "default_tags": {
      "name": "default_tags",
      "type": "map(string)",
      "description": "A map of default tags to apply to all AWS resources",
      "default": {},
      "required": false,
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/variables.tfstack.hcl",
        "line": 17
      }
    },
    "identity_token": {
      "name": "identity_token",
      "type": "string",
      "default": null,
      "required": true,
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/variables.tfstack.hcl",
        "line": 8
      }
    },
    "regions": {
      "name": "regions",
      "type": "set(string)",
      "default": null,
      "required": true,
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/variables.tfstack.hcl",
        "line": 4
      }
    },
    "role_arn": {
      "name": "role_arn",
      "type": "string",
      "default": null,
      "required": true,
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/variables.tfstack.hcl",
        "line": 13
      }
    }
  },
  "outputs": {
    "lambda_urls": {
      "name": "lambda_urls",
      "description": "URLs to invoke lambda functions",
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/outputs.tfstack.hcl",
        "line": 1
      },
      "type": "list(string)"
    }
  },
  "required_providers": {
    "archive": {
      "source": "hashicorp/archive"
    },
    "aws": {
      "source": "hashicorp/aws"
    },
    "local": {
      "source": "hashicorp/local"
    },
    "random": {
      "source": "hashicorp/random"
    }
  },
  "components": {
    "api_gateway": {
      "name": "api_gateway",
      "source": "./api-gateway",
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/components.tfstack.hcl",
        "line": 37
      }
    },
    "lambda": {
      "name": "lambda",
      "source": "./lambda",
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/components.tfstack.hcl",
        "line": 19
      }
    },
    "s3": {
      "name": "s3",
      "source": "./s3",
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/components.tfstack.hcl",
        "line": 4
      }
    }
  },
  "diagnostics": [
    {
      "severity": "error",
      "summary": "Extraneous label for provider",
      "detail": "Only 1 labels (name) are expected for provider blocks.",
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/providers.tfstack.hcl",
        "line": 26
      }
    },
    {
      "severity": "error",
      "summary": "Extraneous label for provider",
      "detail": "Only 1 labels (name) are expected for provider blocks.",
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/providers.tfstack.hcl",
        "line": 43
      }
    },
    {
      "severity": "error",
      "summary": "Extraneous label for provider",
      "detail": "Only 1 labels (name) are expected for provider blocks.",
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/providers.tfstack.hcl",
        "line": 44
      }
    },
    {
      "severity": "error",
      "summary": "Extraneous label for provider",
      "detail": "Only 1 labels (name) are expected for provider blocks.",
      "pos": {
        "filename": "../learn-terraform-stacks-deploy/providers.tfstack.hcl",
        "line": 45
      }
    }
  ]
}
```
 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I’ve documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I’ve worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I’ve worked with GRC to ensure compliance due to a significant change to the cardholder data environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-core). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).