### PR TITLE
Tolerate const vars and locals in module source and version

### DIFF
--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -582,10 +582,7 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 			mod.ModuleCalls[name] = mc
 
 			if attr, defined := content.Attributes["source"]; defined {
-				var source string
-				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &source)
-				diags = append(diags, valDiags...)
-				mc.Source = source
+				mc.Source = decodeModuleSourceOrVersion(attr, file, &diags)
 			}
 
 			if mc.Source == "" {
@@ -593,10 +590,7 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 			}
 
 			if attr, defined := content.Attributes["version"]; defined {
-				var version string
-				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &version)
-				diags = append(diags, valDiags...)
-				mc.Version = version
+				mc.Version = decodeModuleSourceOrVersion(attr, file, &diags)
 			}
 
 		default:
@@ -607,4 +601,25 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 	}
 
 	return diags
+}
+
+// decodeModuleSourceOrVersion decodes a module call's source or version
+// attribute to a string.
+//
+// Terraform 1.15 allows these attributes to reference const input variables and
+// local values (see the module source documentation). Such expressions cannot
+// be evaluated with an empty evaluation context, so when the expression
+// references variables or locals we record its raw source text rather than
+// reporting an error. Constant expressions are decoded as before so that
+// genuinely wrong-typed values still surface as errors.
+func decodeModuleSourceOrVersion(attr *hcl.Attribute, file *hcl.File, diags *hcl.Diagnostics) string {
+	if len(attr.Expr.Variables()) > 0 {
+		rng := attr.Expr.Range()
+		return string(rng.SliceBytes(file.Bytes))
+	}
+
+	var value string
+	valDiags := gohcl.DecodeExpression(attr.Expr, nil, &value)
+	*diags = append(*diags, valDiags...)
+	return value
 }

--- a/tfconfig/load_test.go
+++ b/tfconfig/load_test.go
@@ -82,6 +82,40 @@ func TestLoadStack(t *testing.T) {
 	})
 }
 
+func TestLoadModuleDynamicSource(t *testing.T) {
+	// Terraform 1.15 allows a module's source and version to reference const
+	// input variables and local values. These can't be evaluated with an empty
+	// context, so the loader must fall back to the raw expression rather than
+	// reporting an error.
+	module, diags := LoadModule("testdata/module-dynamic-source")
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %v", diags)
+	}
+
+	cases := map[string]struct {
+		source  string
+		version string
+	}{
+		"child":   {source: "var.child_source", version: "1.0.0"},
+		"sibling": {source: "local.sibling_source", version: "local.sibling_version"},
+		"static":  {source: "app.terraform.io/example-org/static/aws", version: "3.0.0"},
+	}
+
+	for name, want := range cases {
+		mc, exists := module.ModuleCalls[name]
+		if !exists {
+			t.Errorf("module call %q not found", name)
+			continue
+		}
+		if mc.Source != want.source {
+			t.Errorf("module %q source = %q, want %q", name, mc.Source, want.source)
+		}
+		if mc.Version != want.version {
+			t.Errorf("module %q version = %q, want %q", name, mc.Version, want.version)
+		}
+	}
+}
+
 func TestProviderLabels(t *testing.T) {
 	// Test that provider blocks with two labels are correctly parsed
 	stack, diags := LoadStack("testdata-stack/provider-labels")

--- a/tfconfig/testdata/module-dynamic-source/module-dynamic-source.out.json
+++ b/tfconfig/testdata/module-dynamic-source/module-dynamic-source.out.json
@@ -1,0 +1,51 @@
+{
+    "path": "testdata/module-dynamic-source",
+
+    "required_providers": {},
+
+    "variables": {
+        "child_source": {
+            "name": "child_source",
+            "type": "string",
+            "default": "app.terraform.io/example-org/child/aws",
+            "required": false,
+            "pos": {
+                "filename": "testdata/module-dynamic-source/module-dynamic-source.tf",
+                "line": 1
+            }
+        }
+    },
+    "outputs": {},
+
+    "managed_resources": {},
+    "data_resources": {},
+    "module_calls": {
+        "child": {
+            "name": "child",
+            "source": "var.child_source",
+            "version": "1.0.0",
+            "pos": {
+                "filename": "testdata/module-dynamic-source/module-dynamic-source.tf",
+                "line": 12
+            }
+        },
+        "sibling": {
+            "name": "sibling",
+            "source": "local.sibling_source",
+            "version": "local.sibling_version",
+            "pos": {
+                "filename": "testdata/module-dynamic-source/module-dynamic-source.tf",
+                "line": 17
+            }
+        },
+        "static": {
+            "name": "static",
+            "source": "app.terraform.io/example-org/static/aws",
+            "version": "3.0.0",
+            "pos": {
+                "filename": "testdata/module-dynamic-source/module-dynamic-source.tf",
+                "line": 22
+            }
+        }
+    }
+}

--- a/tfconfig/testdata/module-dynamic-source/module-dynamic-source.tf
+++ b/tfconfig/testdata/module-dynamic-source/module-dynamic-source.tf
@@ -1,0 +1,25 @@
+variable "child_source" {
+  type    = string
+  const   = true
+  default = "app.terraform.io/example-org/child/aws"
+}
+
+locals {
+  sibling_source  = "app.terraform.io/example-org/sibling/aws"
+  sibling_version = "2.1.0"
+}
+
+module "child" {
+  source  = var.child_source
+  version = "1.0.0"
+}
+
+module "sibling" {
+  source  = local.sibling_source
+  version = local.sibling_version
+}
+
+module "static" {
+  source  = "app.terraform.io/example-org/static/aws"
+  version = "3.0.0"
+}


### PR DESCRIPTION
Terraform 1.15 allows module source/version to reference const input variables and local values. 

Decode those attributes by recording the raw expression when Variables() is non-empty, instead of failing with an empty eval context. Wrongly typed constant values still error

Fixes [IPL-9617](https://hashicorp.atlassian.net/browse/IPL-9617)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I’ve documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I’ve worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I’ve worked with GRC to ensure compliance due to a significant change to the cardholder data environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-core). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).

[IPL-9617]: https://hashicorp.atlassian.net/browse/IPL-9617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ